### PR TITLE
 - Change example.py to return the response on one of the example han…

### DIFF
--- a/ondewo_bpi/example/example.py
+++ b/ondewo_bpi/example/example.py
@@ -60,8 +60,8 @@ class MyServer(BpiServer):
                       IntentMaxTriggerHandler.handle_if_intent_reached_number_triggers_max],
         )
 
-    def reformat_text_in_intent(self,
-                                response: session_pb2.DetectIntentResponse,
+    @staticmethod
+    def reformat_text_in_intent(response: session_pb2.DetectIntentResponse,
                                 nlu_client: Client) -> session_pb2.DetectIntentResponse:
         return MessageHandler.substitute_pattern(
             pattern="<REPLACE:REPLACE_THIS_TEXT>", replace="new text", response=response
@@ -85,6 +85,7 @@ class MyServer(BpiServer):
                                                      nlu_client: Client) -> session_pb2.DetectIntentResponse:
         logger_console.warning("Intent was triggered a maximum amount of times!")
         IntentMaxTriggerHandler.handle_if_intent_reached_number_triggers_max(response, nlu_client)
+        return response
 
     def serve(self) -> None:
         super().serve()

--- a/ondewo_bpi/intent_max_trigger_handler.py
+++ b/ondewo_bpi/intent_max_trigger_handler.py
@@ -88,8 +88,7 @@ class IntentMaxTriggerHandler:
         return context
 
     @classmethod
-    def handle_if_intent_reached_number_triggers_max(cls, nlu_response: DetectIntentResponse, nlu_client: Client) -> \
-            Optional[DetectIntentResponse]:
+    def handle_if_intent_reached_number_triggers_max(cls, nlu_response: DetectIntentResponse, nlu_client: Client) -> DetectIntentResponse:
         nlu_response_dict: Dict = MessageToDict(nlu_response)
         intent_name: str = nlu_response_dict['queryResult']['intent']['displayName']
         language_code: str = nlu_response_dict['queryResult']["languageCode"]
@@ -100,5 +99,5 @@ class IntentMaxTriggerHandler:
             nlu_response: DetectIntentResponse = nlu_client.services.sessions.detect_intent(
                 request=nlu_request,
             )
-            return nlu_response
-        return None
+                
+        return nlu_response

--- a/ondewo_bpi/intent_max_trigger_handler.py
+++ b/ondewo_bpi/intent_max_trigger_handler.py
@@ -77,10 +77,11 @@ class IntentMaxTriggerHandler:
         # intent_name in display_name and parameter "dictionary" are hardcoded. So don't change them
         parameter: Dict[str, context_pb2.Context.Parameter] = {'intent_name': context_parameter}
 
-        # Don't change the name, just change the lifespan_count, which defines how many times this context is going to be injected
+        # Don't change the name, just change the lifespan_count,
+        #   which defines how many times this context is going to be injected.
         context = context_pb2.Context(
             name=f"{session_id}/contexts/exact_intent",
-            lifespan_count=20,
+            lifespan_count=1,  # Note: the intent will be set only for the next interaction and then decay
             parameters=parameter
         )
 


### PR DESCRIPTION
- Change `example.py` to return the response on one of the example handlers
- Set the context exact intent match to have by default "1" as lifespan