### PR TITLE
Correct overrided qa message

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,7 +14,7 @@
 
 ### Improvements
 
-* Extend the Q&A BPI version to support filte<ring functionality through context injection
+* Extend the Q&A BPI version to support filtering functionality through context injection
 
 The Q&A URL filter can be leveraged to control which resources can Q&A look into for answers.
 The resources are identified by their URLs, therefore, the filters are regexes applied to the URLS.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,11 +2,19 @@
 
 *****************
 
+## Release ONDEWO BPI v4.1.1
+
+### Bug Fixes
+
+* QA Response. The original QA response is no longer overridden by the QA response to track in the CAI.
+
+*****************
+
 ## Release ONDEWO BPI v4.1.0
 
 ### Improvements
 
-* Extend the Q&A BPI version to support filtering functionality through context injection
+* Extend the Q&A BPI version to support filte<ring functionality through context injection
 
 The Q&A URL filter can be leveraged to control which resources can Q&A look into for answers.
 The resources are identified by their URLs, therefore, the filters are regexes applied to the URLS.

--- a/ondewo_bpi_qa/constants.py
+++ b/ondewo_bpi_qa/constants.py
@@ -5,3 +5,6 @@ QA_URL_DEFAULT_FILTER: str = '.*'
 
 CAI_RESPONSE_NAME: str = 'cai_response'
 QA_RESPONSE_NAME: str = 'qa_response'
+
+QA_PUBLIC_IMAGE_URI_LINK: str = \
+    'https://ondewo.com/wp-content/uploads/2020/11/ONDEWO_Logo_4c_vertical_rgb_2019-Phone.png'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setuptools.setup(
     name="ondewo-bpi",
-    version="4.1.0",
+    version="4.1.1",
     author="Ondewo GbmH",
     author_email="info@ondewo.com",
     description="This library starts a proxy for the cai server allowing for fulfillment hooks.",


### PR DESCRIPTION
## Release ONDEWO BPI v4.1.1

### Bug Fixes

* QA Response. The original QA response is no longer overridden by the QA response to track in the CAI.